### PR TITLE
Guard against null releases

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -6,12 +6,7 @@ env:
 
 on:
   push:
-    branches:
-      - main
-      - dev
   pull_request:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       addon:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,11 +2,7 @@ name: Lint
 
 on:
   push:
-    branches:
-      - main
   pull_request:
-    branches:
-      - main
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/sync-release.yaml
+++ b/.github/workflows/sync-release.yaml
@@ -64,6 +64,11 @@ jobs:
           VERSION="${TAG#v}"
           jq -r '.body' /tmp/release_info.json > /tmp/release_notes.md
 
+          if [[ -z "${VERSION}" || "${VERSION}" == "null" ]]; then
+            echo "Invalid version: ${VERSION}"
+            exit 1
+          fi
+
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Get current addon version
@@ -187,6 +192,11 @@ jobs:
 
           VERSION="${TAG#v}"
           jq -r '.body' /tmp/beta_release_info.json > /tmp/beta_release_notes.md
+
+          if [[ -z "${VERSION}" || "${VERSION}" == "null" ]]; then
+            echo "Invalid version: ${VERSION}"
+            exit 1
+          fi
 
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 

--- a/donetick/CHANGELOG.md
+++ b/donetick/CHANGELOG.md
@@ -69,9 +69,6 @@ Big thanks to all the contributions in this release! Thank you for making Doneti
 
 **Full Changelog**: https://github.com/donetick/donetick/compare/v0.1.74...v0.1.75
 
-## null:
-null
-
 ## 0.1.75:
 ## Release Notes:
 We have big release and will be updating the note in the next couple days! Because am sure I miss few things!

--- a/donetick/CHANGELOG.md
+++ b/donetick/CHANGELOG.md
@@ -1,8 +1,5 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
-## null:
-null
-
 ## 0.1.75:
 ## Release Notes:
 We have big release and will be updating the note in the next couple days! Because am sure I miss few things!

--- a/donetick/config.yaml
+++ b/donetick/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: Donetick Addon
-version: "null"
+version: "0.1.75"
 slug: Donetick
 description: Simplify Tasks & Chores, Together.
 url: "https://github.com/Donetick/hassio-addons/tree/main/donetick"


### PR DESCRIPTION
- Guard against `null` releases by exiting the workflow early
- Revert two empty releases
- Disable unnecessary branch filters on workflow jobs